### PR TITLE
Fix steps not reseting on reset

### DIFF
--- a/src/evolution/worker/middleware.js
+++ b/src/evolution/worker/middleware.js
@@ -156,9 +156,4 @@ export const handleControls = store => next => action => {
   next(action)
 }
 
-const logger = store => next => action => {
-  next(action)
-  console.log(action.type, store.getState().step)
-}
-
-export default [handleExpression, handleControls, logger]
+export default [handleExpression, handleControls]

--- a/src/evolution/worker/middleware.js
+++ b/src/evolution/worker/middleware.js
@@ -48,12 +48,12 @@ export const handleExpression = store => next => action => {
   }
 
   if (type === EVOLUTION_PROGRESS) {
-    next(action)
-
     const { payload: result } = action
     const { hasReset } = store.getState()
 
     if (!hasReset) {
+      next(action)
+
       if (action.meta && action.meta.throttle) {
         if (result.loss <= LOSS_THRESHOLD) {
           postMessage(action)
@@ -156,4 +156,9 @@ export const handleControls = store => next => action => {
   next(action)
 }
 
-export default [handleExpression, handleControls]
+const logger = store => next => action => {
+  next(action)
+  console.log(action.type, store.getState().step)
+}
+
+export default [handleExpression, handleControls, logger]


### PR DESCRIPTION
When resetting while evolving the step value in the state of the web worker was set after being reset. Making it seem like it was never reset.

Closes #25 