### PR TITLE
Improved controls and fix prediction equation constant keys

### DIFF
--- a/src/components/CircleButton/CircleButton.js
+++ b/src/components/CircleButton/CircleButton.js
@@ -49,6 +49,12 @@ const CircleButton = styled.button`
     transition: background-color 80ms ease-out;
     background-color: ${({ theme }) => fade(0.95, theme.title)};
   }
+
+  &:disabled {
+    color: ${({ theme }) => fade(0.6, theme.title)};
+    background-color: transparent;
+    cursor: default;
+  }
 `
 
 CircleButton.propTypes = {

--- a/src/components/Divider/Divider.js
+++ b/src/components/Divider/Divider.js
@@ -10,15 +10,20 @@ const Divider = styled.hr`
   border-width: ${({ size }) => size}px;
   border-top-style: solid;
   border-right-style: solid;
-  border-color: ${({ theme }) => theme.border.divider};
+  border-color: ${({ theme, variant }) => {
+    if (variant === 'divider') return theme.border.divider
+    if (variant === 'content') return theme.border.content
+  }};
 `
 
 Divider.defaultProps = {
   size: 2,
+  variant: 'divider',
 }
 
 Divider.propTypes = {
   size: PropTypes.number,
+  variant: PropTypes.oneOf(['divider', 'content']),
 }
 
 export default Divider

--- a/src/components/Menu/Menu.js
+++ b/src/components/Menu/Menu.js
@@ -1,5 +1,6 @@
+import { dependencies } from '../../../package.json'
 import React from 'react'
-import styled from 'styled-components'
+import styled, { css } from 'styled-components'
 import Divider from '../Divider'
 import Download from '../../icons/Download'
 import NewPage from '../../icons/NewPage'
@@ -21,35 +22,46 @@ export const Row = styled.li`
   min-height: 36px;
   background-color: transparent;
   transition: background-color 100ms ease-out;
-  cursor: pointer;
   padding-left: 20px;
   padding-right: 15px;
 
-  &:hover {
-    background-color: ${({ theme }) => theme.surface.regular};
-  }
+  ${({ clickable }) =>
+    clickable &&
+    css`
+      cursor: pointer;
+
+      &:hover {
+        background-color: ${({ theme }) => theme.surface.regular};
+      }
+    `}
 `
 
 const Grow = styled.span`
   flex-grow: 1;
 `
 
+const Code = styled.code`
+  font-size: 0.93em;
+`
+
 const Menu = ({ isOpen, ...restProps }) => {
   return (
     <div {...restProps}>
       <List css="margin: 0;">
+        <Row>
+          <Code>dcpg.js {dependencies.dcgp.replace('^', '')}</Code>
+        </Row>
+        <Divider variant="content" size={1} css="margin: 8px 0px 8px 20px;" />
         <Row>Advanced mode</Row>
-        <Divider size={1} css="margin: 8px 0;" />
         <Row>
           <Grow>Download expression</Grow>
           <Download size={20} />
         </Row>
-        <Divider size={1} css="margin: 8px 0;" />
         <a
           css="text-decoration: none;"
           href="https://github.com/mikeheddes/dcgp-web"
         >
-          <Row>
+          <Row clickable>
             <Grow>GitHub repository</Grow>
             <NewPage size={20} />
           </Row>
@@ -58,12 +70,13 @@ const Menu = ({ isOpen, ...restProps }) => {
           css="text-decoration: none;"
           href="https://github.com/mikeheddes/dcgp-web/issues/new"
         >
-          <Row>
+          <Row clickable>
             <Grow>Report an issue</Grow>
             <NewPage size={20} />
           </Row>
         </a>
       </List>
+      <div css="margin-top: auto;" />
     </div>
   )
 }

--- a/src/components/QuantityCounter/QuantityCounter.js
+++ b/src/components/QuantityCounter/QuantityCounter.js
@@ -1,9 +1,17 @@
 import React, { useCallback } from 'react'
+import PropTypes from 'prop-types'
 import AddCircle from '../../icons/AddCircle'
 import SubtractCircle from '../../icons/SubtractCircle'
 import { Wrapper, Input, Button } from './style'
 
-const QuantityCounter = ({ value, onChange, min, max }) => {
+const QuantityCounter = ({
+  value,
+  onChange,
+  min,
+  max,
+  tabIndex,
+  ...restProps
+}) => {
   const handleInputChange = useCallback(
     event => {
       const val = event.target.valueAsNumber
@@ -25,24 +33,40 @@ const QuantityCounter = ({ value, onChange, min, max }) => {
   const handleIncrement = () => onChange(value + 1)
 
   return (
-    <Wrapper>
+    <Wrapper {...restProps}>
       <Button
         onClick={handleDecrement}
         title="Decrement"
         disabled={value <= min}
+        tabIndex={-1}
       >
         <SubtractCircle />
       </Button>
-      <Input value={value} min={min} max={max} onChange={handleInputChange} />
+      <Input
+        value={value}
+        min={min}
+        max={max}
+        onChange={handleInputChange}
+        tabIndex={tabIndex}
+      />
       <Button
         onClick={handleIncrement}
         title="Increment"
         disabled={value >= max}
+        tabIndex={-1}
       >
         <AddCircle />
       </Button>
     </Wrapper>
   )
+}
+
+QuantityCounter.defaultProps = {
+  tabIndex: 0,
+}
+
+QuantityCounter.propTypes = {
+  tabIndex: PropTypes.number.isRequired,
 }
 
 export default QuantityCounter

--- a/src/evolution/worker/middleware/predictions.js
+++ b/src/evolution/worker/middleware/predictions.js
@@ -48,15 +48,30 @@ const handlePredictions = store => next => action => {
       predictions.push(predictionObj)
     }
 
-    const constantKeys = constants.map((val, i) => `C${i + 1}`)
+    // Set the constants keys to be some recognisable string
+    // that is not likely to be in the equation.
+    // This is because the simplifier doesn't allow some characters
+    // or interprets the equation differently.
+    const constantKeys = constants.map((val, i) => `VAR${i + 1}ENDBRACE`)
 
     const naiveEquations = expression.equations(...inputKeys, ...constantKeys)
     const simplifiedEquations = naiveEquations.map(eq =>
       math
-        .simplify(eq)
+        .simplify(eq, [
+          { l: 'n+0', r: 'n' },
+          { l: 'n^0', r: '1' },
+          { l: '0*n', r: '0' },
+          { l: 'n/n', r: '1' },
+          { l: 'n^1', r: 'n' },
+          { l: '+n1', r: 'n1' },
+          { l: 'n--n1', r: 'n+n1' },
+        ])
         .toTex()
         .replace(/Infinity/g, ' \\infty')
-        .replace(/C/g, 'C_')
+        // replace the 'unique' constant key values to be the
+        // correct LaTeX representation.
+        .replace(/ENDBRACE/g, '}')
+        .replace(/VAR/g, 'C_{')
     )
 
     if (chromosome) {

--- a/src/settings/actions.js
+++ b/src/settings/actions.js
@@ -122,12 +122,17 @@ export const setAlgorithm = algorithmId => ({
 
 export const ADD_CONSTANT = prefix + 'ADD_CONSTANT'
 export const SET_CONSTANT = prefix + 'SET_CONSTANT'
+export const RESET_CONSTANTS = prefix + 'RESET_CONSTANTS'
 export const REMOVE_CONSTANT = prefix + 'REMOVE_CONSTANT'
 export const CHANGE_CONSTANT = prefix + 'CHANGE_CONSTANT'
 export const MAX_CONSTANTS = 10
 
 export const addConstant = () => ({
   type: ADD_CONSTANT,
+})
+
+export const resetConstants = () => ({
+  type: RESET_CONSTANTS,
 })
 
 export const setConstants = constants => ({

--- a/src/settings/components/Constants/Constants.js
+++ b/src/settings/components/Constants/Constants.js
@@ -6,11 +6,13 @@ import {
   addConstant,
   removeConstant,
   changeConstant,
+  resetConstants,
   MAX_CONSTANTS,
 } from '../../actions'
 import List, { Row } from '../List'
 import Remove from '../../../icons/Remove'
 import Plus from '../../../icons/Plus'
+import Reset from '../../../icons/Reset'
 import CircleButton from '../../../components/CircleButton'
 import { SubHeader, Input } from './style'
 
@@ -25,14 +27,46 @@ const Constants = () => {
   const handleRemoveConstant = useCallback(i => () =>
     dispatch(removeConstant(i))
   )
-  const handleChangeConstant = useCallback(i => e =>
-    dispatch(changeConstant(i, e.target.valueAsNumber))
-  )
+  const handleResetConstants = useCallback(() => dispatch(resetConstants()))
+
+  // Allows typing negative numbers
+  const handleChangeConstant = useCallback(i => e => {
+    const inputValue = e.target.value
+
+    if (inputValue === '-' || inputValue === '') {
+      dispatch(changeConstant(i, inputValue))
+      return
+    }
+
+    if (inputValue.endsWith('.') && !isNaN(parseFloat(inputValue + '0'))) {
+      dispatch(changeConstant(i, inputValue))
+      return
+    }
+
+    const parsedValue = parseFloat(inputValue)
+
+    if (isNaN(parsedValue)) {
+      return
+    }
+
+    dispatch(changeConstant(i, parsedValue))
+  })
 
   return (
     <>
       <SubHeader>
         <span css="flex-grow: 1;">Constants</span>
+        <CircleButton
+          css="margin-right: 4px;"
+          title="Reset constants"
+          variant="ghost"
+          size={24}
+          padding={4}
+          onClick={handleResetConstants}
+          disabled={constants.length === 0 || isEvolving}
+        >
+          <Reset size={null} />
+        </CircleButton>
         <CircleButton
           title="Add constant"
           variant="ghost"
@@ -41,7 +75,7 @@ const Constants = () => {
           onClick={handleAddConstant}
           disabled={constants.length >= MAX_CONSTANTS}
         >
-          <Plus />
+          <Plus size={null} />
         </CircleButton>
       </SubHeader>
       <List css="margin-top: 8px; margin-bottom: 8px;">
@@ -51,8 +85,8 @@ const Constants = () => {
             <Input
               disabled={isEvolving}
               value={constant}
-              type="number"
               onChange={handleChangeConstant(i)}
+              tabIndex={i + 1}
             />
             <CircleButton
               title="Remove"

--- a/src/settings/components/Constants/style.js
+++ b/src/settings/components/Constants/style.js
@@ -11,7 +11,7 @@ export const SubHeader = styled.h3`
   align-items: center;
 `
 
-export const Input = styled.input.attrs({ type: 'number' })`
+export const Input = styled.input.attrs({ type: 'text' })`
   flex-grow: 1;
   appearance: none;
   margin: 0 15px;

--- a/src/settings/components/Network/Network.js
+++ b/src/settings/components/Network/Network.js
@@ -10,6 +10,15 @@ import Constants from '../Constants'
 
 const networkSettingIds = Object.keys(networkSettingsById)
 
+const calcMaxValue = (settingId, values) => {
+  if (settingId === 'levelsBack') {
+    // columns + 1 because the levelsBack may also reach the inputs
+    return Math.min(values.columns + 1, networkSettingsById[settingId].max)
+  }
+
+  return networkSettingsById[settingId].max
+}
+
 const mapStateToProps = {
   network: networkSelector,
 }
@@ -33,7 +42,7 @@ const Network = () => {
               value={network[settingId]}
               onChange={handleChange(settingId)}
               min={networkSettingsById[settingId].min}
-              max={networkSettingsById[settingId].max}
+              max={calcMaxValue(settingId, network)}
             />
           </Row>
         ))}

--- a/src/settings/middleware.js
+++ b/src/settings/middleware.js
@@ -3,6 +3,8 @@ import {
   NETWORK_CHANGE,
   ADD_CONSTANT,
   MAX_CONSTANTS,
+  RESET_CONSTANTS,
+  setConstants,
   SET_ALGORITHM,
   setRows,
   setColumns,
@@ -10,7 +12,7 @@ import {
   setLevelsBack,
   REMOVE_CONSTANT,
 } from './actions'
-import { constantsSelector } from './selectors'
+import { constantsSelector, networkSelector } from './selectors'
 import { resetEvolution, sendWorkerMessage } from '../evolution/actions'
 import { isEvolvingSelector } from '../evolution/selectors'
 
@@ -47,6 +49,11 @@ export const handleNetworkChange = store => next => action => {
         break
       case 'columns':
         dispatch(setColumns(value))
+        // set the levels back if it will be higher than coloms + 1
+        // value + 1 because the levelsBack may also reach the inputs
+        if (value + 1 < networkSelector(store.getState()).levelsBack) {
+          dispatch(setLevelsBack(value + 1))
+        }
         break
       case 'arity':
         dispatch(setArity(value))
@@ -73,6 +80,18 @@ export const handleConstants = store => next => action => {
     next({ ...action, payload: initialConstant })
 
     store.dispatch(resetEvolution())
+    return
+  }
+
+  if (action.type === RESET_CONSTANTS) {
+    const constants = constantsSelector(store.getState())
+    next(action)
+
+    const newConstants = Array(constants.length)
+      .fill(0)
+      .map((val, i) => i + 1)
+
+    next(setConstants(newConstants))
     return
   }
 


### PR DESCRIPTION
- Allow users to type negative constants, closes #47.
- Create correct LaTeX equation with 10th constant `C_{10}`, closes #49.
- Keeps a 'link' between the **columns** and the **levels back** to better inform the user on what is actually happening, closes #50.
- Pressing `TAB` when focused on a constant or network setting will focus the next constant or setting.
- Adds the `dcpg.js` version that is being used on the website in the menu.
- Adds ability to reset constants to original initialised values.
- Adds rules to further simplify the prediction equations.