### PR TITLE
Enable tabular font setting

### DIFF
--- a/src/evolution/components/Information/Information.js
+++ b/src/evolution/components/Information/Information.js
@@ -11,7 +11,7 @@ import {
 } from '../../../dataset/selectors'
 import Warning from '../../../icons/Warning'
 import Error from '../../../icons/Error'
-import { List, Row, Bold, Icon, Label } from './style'
+import { List, Row, Bold, Icon, Label, TabularNumbers } from './style'
 
 const significant4 = number => number.toPrecision(4)
 
@@ -54,11 +54,11 @@ const Information = () => {
             <Warning />
           </Icon>
         )}
-        {loss && significant4(loss)}
+        <TabularNumbers>{loss && significant4(loss)}</TabularNumbers>
       </Row>
       <Row>
         <Bold>Step:</Bold>
-        {currentStep}
+        <TabularNumbers>{currentStep}</TabularNumbers>
       </Row>
     </List>
   )

--- a/src/evolution/components/Information/style.js
+++ b/src/evolution/components/Information/style.js
@@ -33,3 +33,7 @@ export const Icon = styled.span`
   }};
   display: flex;
 `
+
+export const TabularNumbers = styled.span`
+  font-feature-settings: 'tnum' 1;
+`

--- a/src/styles/GlobalStyle.js
+++ b/src/styles/GlobalStyle.js
@@ -9,16 +9,13 @@ export default createGlobalStyle`
   body {
     background-color: ${({ theme }) => theme.background};
     color: ${({ theme }) => theme.title};
-    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen",
-      "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue",
-      sans-serif;
+    font-family: -apple-system, BlinkMacSystemFont, Segoe UI, Helvetica, Arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol;
     -webkit-font-smoothing: antialiased;
     -moz-osx-font-smoothing: grayscale;
   }
 
   code, pre {
-    font-family: source-code-pro, Menlo, Monaco, Consolas, "Courier New",
-      monospace;
+    font-family: source-code-pro, Menlo, Monaco, Consolas, "Courier New", monospace;
   }
 
   .katex-display {


### PR DESCRIPTION
Tabular numbers makes it easier to track the number when rapidly changing. This PR also cleans up the fallback font list.